### PR TITLE
Update upstream auto-embed to vidfast pro

### DIFF
--- a/cinecraze.html
+++ b/cinecraze.html
@@ -799,7 +799,6 @@
             margin: 0 12px 0 0;
             cursor: pointer;
         }
-
         .content-checkbox-item.disabled input[type="checkbox"] {
             cursor: not-allowed;
         }
@@ -1354,7 +1353,6 @@
             border: 1px solid rgba(255, 165, 0, 0.3);
         }
     </style>
-    
     <!-- GitHub Upload Script -->
     <script>
         // GitHub Upload Configuration
@@ -2499,7 +2497,7 @@ jobs:
                             </div>
                             <div class="embed-option">
                                 <input type="checkbox" id="auto-upstream" checked>
-                                <label for="auto-upstream">UpStream Auto-Embed</label>
+                                <label for="auto-upstream">VidFast Auto-Embed</label>
                                 <select id="upstream-quality">
                                     <option value="1080p">1080p</option>
                                     <option value="720p">720p</option>
@@ -2674,10 +2672,9 @@ jobs:
         const VIDCLOUD_BASE = 'https://vidcloud.to/embed';
         const STREAMWISH_BASE = 'https://streamwish.to/e';
         const DOODSTREAM_BASE = 'https://doodstream.com/e';
-        const UPSTREAM_BASE = 'https://upstream.to';
+        const UPSTREAM_BASE = 'https://vidfast.pro';
         const STREAMTAPE_BASE = 'https://streamtape.com/e';
         const MIXDROP_BASE = 'https://mixdrop.co/e';
-const GODRIVEPLAYER_BASE = 'https://godriveplayer.com/embed';
 const TWOTWOEMBED_BASE = 'https://2embed.cc/embed';
         
         // Get current TMDB API key
@@ -3468,7 +3465,6 @@ const TWOTWOEMBED_BASE = 'https://2embed.cc/embed';
                 resultsContainer.innerHTML = '';
             }
         }
-
         function displaySearchResults(results, title = 'Search Results') {
             const container = document.getElementById('search-results');
             container.innerHTML = `<h3>${title}</h3>`;
@@ -3860,8 +3856,10 @@ const TWOTWOEMBED_BASE = 'https://2embed.cc/embed';
                         match = url.match(/player\.videasy\.net\/tv\/(\d+)\/(\d+)\/(\d+)/);
                         if (match) return match[1];
                         
-                        // UpStream format: https://upstream.to/embed-TMDB_ID
-                        match = url.match(/upstream\.to\/embed-(\d+)/);
+                        // VidFast format: https://vidfast.pro/movie/TMDB_ID or /tv/TMDB_ID/SEASON/EPISODE
+                        match = url.match(/vidfast\.pro\/movie\/(\d+)/);
+                        if (match) return match[1];
+                        match = url.match(/vidfast\.pro\/tv\/(\d+)\/(\d+)\/(\d+)/);
                         if (match) return match[1];
                     }
                 }
@@ -5023,7 +5021,6 @@ const TWOTWOEMBED_BASE = 'https://2embed.cc/embed';
             
             showLoading('import-loading', false);
         }
-        
         function updateImportProgress(percent, processed, message, category, speed = 0, eta = 0) {
             // Update progress bar
             document.getElementById('import-progress-fill').style.width = `${percent}%`;
@@ -7037,16 +7034,16 @@ Proceed with removal?`;
                 });
             }
 
-            // UpStream
+            // VidFast
             if (config.upstream.enabled) {
                 let url;
                 if (contentType === 'tv' && seasonNum && episodeNum) {
-                    url = `${UPSTREAM_BASE}/embed-${tmdbId}s${seasonNum}e${episodeNum}.html`;
+                    url = `${UPSTREAM_BASE}/tv/${tmdbId}/${seasonNum}/${episodeNum}`;
                 } else {
-                    url = `${UPSTREAM_BASE}/embed-${tmdbId}.html`;
+                    url = `${UPSTREAM_BASE}/movie/${tmdbId}`;
                 }
                 sources.push({
-                    name: `UpStream ${config.upstream.quality}`,
+                    name: `VidFast ${config.upstream.quality}`,
                     subtitle1: "", subtitle2: "", url: url
                 });
             }
@@ -7123,7 +7120,7 @@ Proceed with removal?`;
                     server.url.includes('streamtape.com') ||
                     server.url.includes('mixdrop.co') ||
                     server.url.includes('player.videasy.net') ||
-                    server.url.includes('upstream.to') ||
+                    server.url.includes('vidfast.pro') ||
                     server.url.includes('godriveplayer.com') ||
                     server.url.includes('2embed.cc') ||
                     server.url.includes('vidlink.pro')
@@ -7149,7 +7146,7 @@ Proceed with removal?`;
                     server.name.includes('StreamTape') ||
                     server.name.includes('MixDrop') ||
                     server.name.includes('VidEasy') ||
-                    server.name.includes('UpStream') ||
+                    server.name.includes('VidFast') ||
                     server.name.includes('GoDrivePlayer') ||
                     server.name.includes('2Embed') ||
                     server.name.includes('VidLink')
@@ -7184,7 +7181,7 @@ Proceed with removal?`;
                 !server.url.includes('streamtape.com') &&
                 !server.url.includes('mixdrop.co') &&
                 !server.url.includes('player.videasy.net') &&
-                !server.url.includes('upstream.to') &&
+                !server.url.includes('vidfast.pro') &&
                 !server.url.includes('godriveplayer.com') &&
                 !server.url.includes('2embed.cc') &&
                 !server.url.includes('vidlink.pro')
@@ -7265,7 +7262,6 @@ Proceed with removal?`;
             saveData();
             updateDataStats();
         }
-
         function applyAutoEmbedToAll() {
             const filterType = document.getElementById('auto-embed-filter').value;
             let totalProcessed = 0;
@@ -8029,7 +8025,6 @@ Proceed with removal?`;
                 console.error(`⚠️ Error updating episode metadata:`, error);
             }
         }
-        
         function updateSelectedContentInfo() {
             const select = document.getElementById('auto-embed-content-select');
             const infoDiv = document.getElementById('selected-content-info');


### PR DESCRIPTION
Replace UpStream Auto-Embed functionality with VidFast Auto-Embed to switch the content embedding provider.

---
<a href="https://cursor.com/background-agent?bcId=bc-826c22e9-4725-4db2-bec8-5d84f04aa125">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-826c22e9-4725-4db2-bec8-5d84f04aa125">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

